### PR TITLE
feat: add invoice creation flow

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -37,8 +37,23 @@ function renderCart() {
   });
 }
 
-function checkout() {
-  alert('Checkout will open Telegram Payments next. 👍');
+async function checkout() {
+  try {
+    const user = Telegram?.WebApp?.initDataUnsafe?.user;
+    const res = await fetch('/api/create-invoice', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ cart, user })
+    });
+    const { invoiceLink } = await res.json();
+    if (invoiceLink) {
+      window.location.href = invoiceLink;
+    } else {
+      alert('Could not create invoice.');
+    }
+  } catch (err) {
+    alert('Could not create invoice.');
+  }
 }
 
 renderProducts();


### PR DESCRIPTION
## Summary
- implement checkout to POST cart and user to /api/create-invoice
- redirect to invoice link returned to start Telegram payment
- alert users if invoice creation fails

## Testing
- `npm test` (fails: Missing script: "test")

------
https://chatgpt.com/codex/tasks/task_e_6899f536bba48333b1690dc3c9b698ce