### PR TITLE
feat: add product details and visual feedback

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -1,7 +1,25 @@
 const products = [
-  { id: 1, name: 'Telegram Bot Setup', price: 5 },
-  { id: 2, name: 'Custom Prompt Pack', price: 3 },
-  { id: 3, name: 'Mini App Template', price: 7 }
+  {
+    id: 1,
+    name: 'Telegram Bot Setup',
+    price: 5,
+    image: 'https://via.placeholder.com/150',
+    description: 'Get your bot configured and ready to serve your users.'
+  },
+  {
+    id: 2,
+    name: 'Custom Prompt Pack',
+    price: 3,
+    image: 'https://via.placeholder.com/150',
+    description: 'A curated set of prompts to inspire creativity.'
+  },
+  {
+    id: 3,
+    name: 'Mini App Template',
+    price: 7,
+    image: 'https://via.placeholder.com/150',
+    description: 'Kickstart your mini app development with this template.'
+  }
 ];
 
 const cart = [];
@@ -10,11 +28,13 @@ function renderProducts() {
   const container = document.getElementById('products');
   container.innerHTML = '';
   products.forEach(product => {
-    const card = document.createElement('div');
+    const card = document.createElement('article');
     card.className = 'card';
     card.innerHTML = `
+      ${product.image ? `<img src="${product.image}" alt="${product.name}">` : ''}
       <h3>${product.name}</h3>
-      <div class="price">\$${product.price} USD</div>
+      ${product.description ? `<p>${product.description}</p>` : ''}
+      <div class="price">$${product.price} USD</div>
       <button onclick="addToCart(${product.id})">Add to Cart</button>
     `;
     container.appendChild(card);

--- a/public/index.html
+++ b/public/index.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>AetherStore</title>
+  <link rel="stylesheet" href="./styles.css" />
   <style>
     body { font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif; background:#111; color:#fff; margin:0; padding:16px; }
     h1 { margin-top:0 }

--- a/public/styles.css
+++ b/public/styles.css
@@ -1,0 +1,22 @@
+.card {
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.4);
+  transition: box-shadow 0.2s ease, transform 0.2s ease;
+}
+
+.card:hover,
+.card:focus {
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.6);
+  transform: translateY(-2px);
+  outline: none;
+}
+
+button {
+  transition: background-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+button:hover,
+button:focus {
+  box-shadow: 0 0 0 2px #0ea5e9;
+  background-color: #0284c7;
+  outline: none;
+}


### PR DESCRIPTION
## Summary
- extend products with optional images and descriptions
- show product images and descriptions in article cards
- add card and button visual feedback styles

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_6899f1d748e483339e91de2e78a91de0