### PR TITLE
refactor: external stylesheet with responsive breakpoints

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -4,16 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>AetherStore</title>
-  <style>
-    body { font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif; background:#111; color:#fff; margin:0; padding:16px; }
-    h1 { margin-top:0 }
-    #products { display:grid; grid-template-columns: repeat(auto-fill, minmax(240px,1fr)); gap:12px; }
-    .card { background:#1f1f1f; padding:12px; border-radius:10px; }
-    .card h3 { margin:0 0 6px }
-    .price { font-weight:700; }
-    button { padding:10px 14px; border:none; border-radius:8px; background:#0ea5e9; color:#fff; cursor:pointer; }
-    button:active { transform: translateY(1px); }
-  </style>
+  <link rel="stylesheet" href="./styles.css" />
 </head>
 <body>
   <h1>Welcome to AetherStore</h1>

--- a/public/styles.css
+++ b/public/styles.css
@@ -1,0 +1,29 @@
+body { font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif; background:#111; color:#fff; margin:0; }
+h1 { margin-top:0; }
+#products { display:grid; gap:12px; }
+.card { background:#1f1f1f; padding:12px; border-radius:10px; }
+.card h3 { margin:0 0 6px; }
+.price { font-weight:700; }
+button { border:none; border-radius:8px; background:#0ea5e9; color:#fff; cursor:pointer; }
+button:active { transform: translateY(1px); }
+
+@media (max-width: 599px) {
+  body { font-size:14px; padding:8px; }
+  h1 { font-size:1.5rem; }
+  #products { grid-template-columns:1fr; }
+  button { padding:8px 12px; }
+}
+
+@media (min-width: 600px) and (max-width: 1024px) {
+  body { font-size:15px; padding:12px; }
+  h1 { font-size:1.75rem; }
+  #products { grid-template-columns:repeat(2,1fr); }
+  button { padding:9px 13px; }
+}
+
+@media (min-width: 1025px) {
+  body { font-size:16px; padding:16px; }
+  h1 { font-size:2rem; }
+  #products { grid-template-columns:repeat(3,1fr); }
+  button { padding:10px 14px; }
+}


### PR DESCRIPTION
## Summary
- move inline styles from `index.html` to new `styles.css`
- add responsive breakpoints for small, medium, and large screens
- link external stylesheet and drop inline style block

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6899f1d36aec8333a11433d0018c706d