### PR TITLE
Enhance store visuals

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -1,7 +1,22 @@
 const products = [
-  { id: 1, name: 'Telegram Bot Setup', price: 5 },
-  { id: 2, name: 'Custom Prompt Pack', price: 3 },
-  { id: 3, name: 'Mini App Template', price: 7 }
+  {
+    id: 1,
+    name: 'Telegram Bot Setup',
+    price: 5,
+    image: 'https://via.placeholder.com/240x160?text=Bot'
+  },
+  {
+    id: 2,
+    name: 'Custom Prompt Pack',
+    price: 3,
+    image: 'https://via.placeholder.com/240x160?text=Prompts'
+  },
+  {
+    id: 3,
+    name: 'Mini App Template',
+    price: 7,
+    image: 'https://via.placeholder.com/240x160?text=Template'
+  }
 ];
 
 const cart = [];
@@ -13,6 +28,7 @@ function renderProducts() {
     const card = document.createElement('div');
     card.className = 'card';
     card.innerHTML = `
+      <img src="${product.image}" alt="${product.name}">
       <h3>${product.name}</h3>
       <div class="price">\$${product.price} USD</div>
       <button onclick="addToCart(${product.id})">Add to Cart</button>

--- a/public/index.html
+++ b/public/index.html
@@ -4,15 +4,77 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>AetherStore</title>
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap" rel="stylesheet" />
   <style>
-    body { font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif; background:#111; color:#fff; margin:0; padding:16px; }
-    h1 { margin-top:0 }
-    #products { display:grid; grid-template-columns: repeat(auto-fill, minmax(240px,1fr)); gap:12px; }
-    .card { background:#1f1f1f; padding:12px; border-radius:10px; }
-    .card h3 { margin:0 0 6px }
-    .price { font-weight:700; }
-    button { padding:10px 14px; border:none; border-radius:8px; background:#0ea5e9; color:#fff; cursor:pointer; }
-    button:active { transform: translateY(1px); }
+    body {
+      font-family: 'Poppins', -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+      background: linear-gradient(135deg, #0f0c29, #302b63, #24243e);
+      color: #fff;
+      margin: 0;
+      padding: 16px;
+      min-height: 100vh;
+    }
+    h1 {
+      margin-top: 0;
+      text-align: center;
+    }
+    #products {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+      gap: 20px;
+    }
+    .card {
+      background: rgba(255, 255, 255, 0.08);
+      padding: 16px;
+      border-radius: 12px;
+      box-shadow: 0 8px 16px rgba(0, 0, 0, 0.2);
+      transition: transform 0.2s, box-shadow 0.2s;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+    }
+    .card:hover {
+      transform: translateY(-4px);
+      box-shadow: 0 12px 24px rgba(0, 0, 0, 0.3);
+    }
+    .card img {
+      width: 100%;
+      border-radius: 8px;
+      margin-bottom: 12px;
+    }
+    .card h3 {
+      margin: 0 0 6px;
+      text-align: center;
+    }
+    .price {
+      font-weight: 700;
+      margin-bottom: 8px;
+    }
+    button {
+      padding: 10px 14px;
+      border: none;
+      border-radius: 8px;
+      background: linear-gradient(90deg, #0ea5e9, #2563eb);
+      color: #fff;
+      cursor: pointer;
+      transition: background 0.2s;
+    }
+    button:hover {
+      background: linear-gradient(90deg, #0ea5e9, #1e40af);
+    }
+    button:active {
+      transform: translateY(1px);
+    }
+    #cart {
+      list-style: none;
+      padding: 0;
+    }
+    #cart li {
+      background: rgba(255, 255, 255, 0.05);
+      margin-bottom: 6px;
+      padding: 8px;
+      border-radius: 6px;
+    }
   </style>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- add modern gradient theme and polished cards for a more engaging store UI
- display product images and hover effects to improve visual appeal

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_6899c60556d48333af42faa67fdee701