### PR TITLE
Validate user data before generating invoice

### DIFF
--- a/api/create-invoice.js
+++ b/api/create-invoice.js
@@ -22,6 +22,10 @@ export default async function handler(request, response) {
       return response.status(400).json({ error: 'Cart is invalid or empty.' });
     }
 
+    if (!user || !user.id) {
+      return response.status(400).json({ error: 'User information is missing.' });
+    }
+
     const prices = cart.map(item => ({
       label: item.name,
       amount: item.price * 100 // smallest unit (Agorot)


### PR DESCRIPTION
## Summary
- prevent runtime crashes by validating `user` payload in `create-invoice` API

## Testing
- `npm test` *(fails: Missing script: "test" as no tests are defined)*

------
https://chatgpt.com/codex/tasks/task_e_6899c421925083338cb11594c8b4696f